### PR TITLE
Set kerberos dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "validate-commit-msg": "^2.12.1"
   },
   "dependencies": {
-    "kerberos": "*",
+    "kerberos": "0.0.24",
     "nested-error-stacks": "^2.0.0",
     "pify": "^2.3.0"
   },


### PR DESCRIPTION
The 1.x.x release of kerberos broke all previous APIs, and is no longer compatible. This package should use 0.0.24 until it is adapted to the newer kerberos version.